### PR TITLE
Hide settings by setting top = -outerHeight()

### DIFF
--- a/public/css/forms.less
+++ b/public/css/forms.less
@@ -8,7 +8,6 @@ fieldset{
 #settings{
 	#border-box;
 	position:fixed;
-	top:-1000px;
 	z-index:-1;
 	width:480px;
 	left:50%;

--- a/public/css/forms.less
+++ b/public/css/forms.less
@@ -37,7 +37,6 @@ fieldset{
 		}
 	}
 	&.show{
-		top:65px;
 		opacity:1;
 	}
 }

--- a/public/lib/stream/settingsDialog.js
+++ b/public/lib/stream/settingsDialog.js
@@ -11,14 +11,16 @@ require.def("stream/settingsDialog",
     var visible = false;
     function hide() {
       visible = false;
-      $("#settings").removeClass("show");
+      var elem = $("#settings");
+      elem.removeClass("show").css("top", -elem.outerHeight());
     }
     function show() {
       visible = true;
-      $("#settings").addClass("show");
+      $("#settings").css("top", 65).addClass("show");
     }
     
     function bind() {
+      hide();
       $("#header").delegate(".settings > a", "click", function (e) {
         e.preventDefault();
         


### PR DESCRIPTION
Don't know if this is what you had in mind when you said "We need a new method to hide the settings dialog", but here's one way to do it. Don't know if it's better or worse, my css is incredibly lame. 

Tested on: Chrome beta/OSX, Safari 5.0.1/OSX, Firefox 3.6.8/OSX

(Also: I just wanted to try this github pull request stuff twitter is raving about).
