### PR TITLE
settings.get returns undefined

### DIFF
--- a/public/lib/stream/settings.js
+++ b/public/lib/stream/settings.js
@@ -108,18 +108,20 @@ require.def("stream/settings",
       
       // synchronous get of a settings key in a namespace
       get: function (namespace, key) {
-        var ns = settings[namespace];
-        if(ns) {
-          if(key in ns) {
-            return ns[key]
+        //return setting if possible
+        if (namespace in settings &&
+          key in namespace[settings]) {
+            return settings[namespace][key];
           }
-          else {
+        //no setting? return defaultValue if possible
+        //assumes that if namespace and key exist, they have the expected properties
+        if (namespace in defaultSettings &&
+          key in defaultSettings[namespace].settings) {
             return defaultSettings[namespace].settings[key].defaultValue;
           }
-          return defaultValue;
-        } else {
-          return defaultSettings[namespace].settings[key].defaultValue;
-        }
+        //oops, this key was probably not registered in the namespace
+        console.log("[settings] key "+key+" not found in namespace "+namespace);
+        return undefined;
       },
       
       // set a key in a namespace

--- a/public/lib/stream/settings.js
+++ b/public/lib/stream/settings.js
@@ -121,7 +121,7 @@ require.def("stream/settings",
           }
         //oops, this key was probably not registered in the namespace
         console.log("[settings] key "+key+" not found in namespace "+namespace);
-        return undefined;
+        return null;
       },
       
       // set a key in a namespace

--- a/public/lib/stream/settings.js
+++ b/public/lib/stream/settings.js
@@ -110,7 +110,7 @@ require.def("stream/settings",
       get: function (namespace, key) {
         //return setting if possible
         if (namespace in settings &&
-          key in namespace[settings]) {
+          key in settings[namespace]) {
             return settings[namespace][key];
           }
         //no setting? return defaultValue if possible


### PR DESCRIPTION
You said: 

> You can change settings.get to return null and do a console.log that a non-existing setting was accessed.

Return NULL? What are you, a JAVA programmer? I think you meant undefined :)

Note: I looked at the other settings.js functions, it seems they handle non-existent settings gracefully or throw a descriptive error.

Note2: I'm a bit confused about the state of my original pull request. Is this the last change you need?
