### PR TITLE
use stream.twitter.com instead of betastream.twitter.com

### DIFF
--- a/lib/twitter-stream-client.js
+++ b/lib/twitter-stream-client.js
@@ -10,7 +10,7 @@ function listen(requester, cb) {
   
   var index = conIndex++;
   
-  requester("http://betastream.twitter.com/2b/user.json", "GET", function (error, request) {
+  requester("http://stream.twitter.com/2b/user.json", "GET", function (error, request) {
     if(error) {
       throw error;
     }


### PR DESCRIPTION
After the stability of stream.twitter.com
