### PR TITLE
adding package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+   "name": "streamie",
+   "description": "An extremely hackable full realtime twitter client",
+   "tags": [
+       "twitter",
+       "node",
+       "stream",
+       "client"
+   ],
+   "version": "0.1.0",
+   "author": "Malte Ubl <malte.ubl@gmail.com>",
+   "repository": {
+       "type": "git",
+       "url": "http://github.com/cramforce/streamie.git"
+   },
+   "bugs": "http://github.com/cramforce/streamie/issues",
+   "engines": [
+       "node >= 0.3.0"
+   ],
+   "main": "lib/server.js",
+   "dependencies": {
+       "socket.io": ">=",
+       "oauth": ">=",
+       "node-static": ">=",
+       "nStore": ">=",
+       "http-proxy": ">=",
+       "less": ">="       
+    }
+}


### PR DESCRIPTION
I needed to add a package.json since we have a system in place over here for deploying node applications from package.json files. 

I've also added the deps in the package.json so npm can automatically resolve them. I would suggest adding the version numbers to the deps, so they are locked in ( and latest versions with breaking apis won't affect streamie ).

After this, I'd like to work on the stream server API so we can spawn the service as a CommonJS module in addition to launching straight from terminal. Once this is in place I can help update documentation. 

Let me know what you think.
